### PR TITLE
Add reusable Logo component

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,8 +1,7 @@
 import clsx from "clsx";
-import Image from "next/image";
 import Navbar from "../ui/components/nav/navbar/component";
+import Logo from "../ui/components/logo/component";
 import Colors from "../ui/design/colors/colors";
-import Typography from "../ui/design/typography/typography";
 
 const options = ["About", "Skills", "Works", "Contact"];
 
@@ -15,29 +14,7 @@ export default function Home() {
       )}
     >
       <Navbar options={options} className="mt-[100px]" />
-      <div className="flex flex-row gap-5 items-center justify-center">
-        <Image
-          src="/assets/svg/logo.svg"
-          alt="Logo"
-          width={35.54}
-          height={77.5}
-        />
-        <div className={clsx("flex flex-col items-center justify-center")}>
-          <Typography variant="display" element="h1" themeText="primary">
-            NweVa
-          </Typography>
-          <Typography variant="subtitle" element="h2" themeText="accent">
-            AI & Web Innovations
-          </Typography>
-        </div>
-        <Image
-          src="/assets/svg/logo.svg"
-          alt="Logo"
-          width={35.54}
-          height={77.5}
-          className="rotate-180"
-        />
-      </div>
+      <Logo />
     </div>
   );
 }

--- a/frontend/ui/components/logo/component.tsx
+++ b/frontend/ui/components/logo/component.tsx
@@ -1,0 +1,38 @@
+import Image from "next/image";
+import clsx from "clsx";
+import Typography from "../../design/typography/typography";
+
+interface LogoProps {
+  /**
+   * Scaling factor applied to the default logo size.
+   * 1 corresponds to the dimensions used on the homepage.
+   */
+  size?: number;
+  className?: string;
+}
+
+export default function Logo({ size = 1, className }: LogoProps) {
+  const width = 35.54 * size;
+  const height = 77.5 * size;
+
+  return (
+    <div className={clsx("flex flex-row gap-5 items-center justify-center", className)}>
+      <Image src="/assets/svg/logo.svg" alt="Logo" width={width} height={height} />
+      <div className="flex flex-col items-center justify-center">
+        <Typography variant="display" element="h1" themeText="primary">
+          NweVa
+        </Typography>
+        <Typography variant="subtitle" element="h2" themeText="accent">
+          AI & Web Innovations
+        </Typography>
+      </div>
+      <Image
+        src="/assets/svg/logo.svg"
+        alt="Logo"
+        width={width}
+        height={height}
+        className="rotate-180"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Logo` component for displaying the brand logo with a scalable size
- update homepage to use the new component
- run lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68586b7cd880832ca9c8eda4d1095feb