### PR TITLE
Use clamp for responsive typography

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -24,9 +24,10 @@
   --font-subtitle: var(--font-subtitle);
   --font-text: var(--font-text);
   --font-nav: var(--font-nav);
-  --text-7xl: 64px;
-  --text-5xl: 40px;
-  --text-2xl: 20px;
+  /* Fluid typography based on desktop sizes */
+  --text-7xl: clamp(40px, 5vw + 1rem, 64px);
+  --text-5xl: clamp(24px, 4vw + 1rem, 40px);
+  --text-2xl: clamp(16px, 2vw + 0.5rem, 20px);
   --color-text-primary: #f7e1b8;
   --color-text-secondary: #1f1f1f;
   --color-text-accent: #ff672a;


### PR DESCRIPTION
## Summary
- use CSS `clamp` to make root font sizes responsive

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68586f5a86a4832c99e0c50ded26886d