### PR TITLE
Add reusable button component

### DIFF
--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -1,0 +1,12 @@
+import Colors from "../../ui/design/colors/colors";
+import Typography from "../../ui/design/typography/typography";
+
+export default function AboutPage() {
+  return (
+    <div className={Colors({ themeBackground: "primary" }) + " p-8"}>
+      <Typography variant="title" themeText="accent">
+        About Page
+      </Typography>
+    </div>
+  );
+}

--- a/frontend/app/contact/page.tsx
+++ b/frontend/app/contact/page.tsx
@@ -1,0 +1,12 @@
+import Colors from "../../ui/design/colors/colors";
+import Typography from "../../ui/design/typography/typography";
+
+export default function ContactPage() {
+  return (
+    <div className={Colors({ themeBackground: "primary" }) + " p-8"}>
+      <Typography variant="title" themeText="accent">
+        Contact Page
+      </Typography>
+    </div>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,8 @@
 import clsx from "clsx";
+import Link from "next/link";
 import Navbar from "../ui/components/nav/navbar/component";
 import Logo from "../ui/components/logo/component";
+import Button from "../ui/components/button/component";
 import Colors from "../ui/design/colors/colors";
 
 const options = ["About", "Skills", "Works", "Contact"];
@@ -15,6 +17,56 @@ export default function Home() {
     >
       <Navbar options={options} className="mt-[100px]" />
       <Logo />
+      <div className="flex gap-4">
+        <Link href="/about">
+          <Button
+            variant="accent"
+            iconPosition="right"
+            icon={
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="w-4 h-4"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M17.25 8.25L21 12m0 0l-3.75 3.75M21 12H3"
+                />
+              </svg>
+            }
+          >
+            Learn more
+          </Button>
+        </Link>
+        <Link href="/contact">
+          <Button
+            variant="secondary"
+            iconPosition="left"
+            icon={
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="w-4 h-4"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M2.25 6.75l9.75 7.5 9.75-7.5M4.5 4.5h15a2.25 2.25 0 012.25 2.25v12a2.25 2.25 0 01-2.25 2.25h-15A2.25 2.25 0 012.25 18.75v-12A2.25 2.25 0 014.5 4.5z"
+                />
+              </svg>
+            }
+          >
+            Contact me
+          </Button>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/frontend/ui/components/button/component.tsx
+++ b/frontend/ui/components/button/component.tsx
@@ -1,0 +1,51 @@
+import clsx from "clsx";
+import Colors from "../../design/colors/colors";
+
+export type ButtonVariant = "primary" | "secondary" | "accent";
+export type IconPosition = "left" | "right" | "only";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  icon?: React.ReactNode;
+  iconPosition?: IconPosition;
+  className?: string;
+}
+
+export default function Button({
+  children,
+  variant = "primary",
+  icon,
+  iconPosition = "left",
+  className,
+  ...rest
+}: ButtonProps) {
+  const variantClass = (() => {
+    switch (variant) {
+      case "secondary":
+        return Colors({ themeBackground: "secondary", themeText: "primary" });
+      case "accent":
+        return Colors({ themeBackground: "accent", themeText: "secondary" });
+      default:
+        return Colors({ themeBackground: "primary", themeText: "secondary" });
+    }
+  })();
+
+  const renderIcon = () => icon && <span className="w-5 h-5">{icon}</span>;
+  const showText = iconPosition !== "only";
+
+  return (
+    <button
+      className={clsx(
+        "px-4 py-2 rounded-md flex items-center gap-2 font-nav text-xl",
+        variantClass,
+        className
+      )}
+      {...rest}
+    >
+      {icon && iconPosition === "left" && renderIcon()}
+      {showText && <span>{children}</span>}
+      {icon && iconPosition === "right" && renderIcon()}
+      {icon && iconPosition === "only" && renderIcon()}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- create generic Button component with variant and icon positioning options
- add About and Contact placeholder pages
- add Learn more and Contact me buttons on homepage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68588cda47c0832cb0d1ea953e642ea1